### PR TITLE
Add option `--unit-conversion`

### DIFF
--- a/Cli/ReadCliArgs.cpp
+++ b/Cli/ReadCliArgs.cpp
@@ -83,6 +83,7 @@ std::optional<CliArgs> readCliArgs(int argc_, char *argv_[]) {
   std::string outFile;
   std::string fbmDir;
   std::string logFile;
+  std::string unitConversion;
   std::vector<std::string> textureSearchLocations;
 
   const std::array<std::u8string_view, 2> tslMacros = {u8"cwd",
@@ -105,6 +106,17 @@ std::optional<CliArgs> readCliArgs(int argc_, char *argv_[]) {
       clipp::option("--no-flip-v")
           .set(cliArgs.convertOptions.noFlipV)
           .doc("Do not flip V texture coordinates."),
+
+      clipp::option("--unit-conversion") &
+          clipp::value("unit-conversion", unitConversion)
+              .doc("How to perform unit converseion.\n"
+                   "  - `geometry-level`(default) Do unit conversion at "
+                   "geometry "
+                   "level.\n"
+                   "  - `hierarchy-level` Do unit conversion at hierarchy "
+                   "level.\n"
+                   "  - `disabled` Disable unit conversion. This may cause the "
+                   "generated glTF does't conform to glTF specification."),
 
       clipp::option("--no-texture-resolution")
           .set(cliArgs.convertOptions.textureResolution.disabled)
@@ -189,6 +201,21 @@ std::optional<CliArgs> readCliArgs(int argc_, char *argv_[]) {
     std::cout << make_man_page(
         cli, commandLineArgsU8->empty() ? "" : commandLineArgsU8->front());
     return {};
+  }
+
+  if (!unitConversion.empty()) {
+    if (unitConversion == "geometry-level") {
+      cliArgs.convertOptions.unitConversion =
+          bee::ConvertOptions::UnitConversion::geometryLevel;
+    } else if (unitConversion == "hierarchy-level") {
+      cliArgs.convertOptions.unitConversion =
+          bee::ConvertOptions::UnitConversion::hierarchyLevel;
+    } else if (unitConversion == "disabled") {
+      cliArgs.convertOptions.unitConversion =
+          bee::ConvertOptions::UnitConversion::disabled;
+    } else {
+      std::cerr << "Unknown unit conversion option: " << unitConversion << "\n";
+    }
   }
 
   cliArgs.inputFile.assign(inputFile.begin(), inputFile.end());

--- a/Core/Source/bee/Convert/SceneConverter.Animation.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Animation.cpp
@@ -367,7 +367,7 @@ void SceneConverter::_extractTrsAnimation(fx::gltf::Animation &glTF_animation_,
     const auto time = fbxTime.GetSecondDouble();
     fbxsdk::FbxVector4 translation;
     if (isTranslationAnimated) {
-      translation = localTransform.GetT();
+      translation = _applyUnitScaleFactorV3(localTransform.GetT());
     }
     fbxsdk::FbxQuaternion rotation;
     if (isRotationAnimated) {

--- a/Core/Source/bee/Convert/SceneConverter.Mesh.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Mesh.cpp
@@ -145,8 +145,8 @@ SceneConverter::_getGeometrixTransform(fbxsdk::FbxNode &fbx_node_) {
       fbx_node_.GetGeometricRotation(fbxsdk::FbxNode::EPivotSet::eSourcePivot);
   const auto meshScaling =
       fbx_node_.GetGeometricScaling(fbxsdk::FbxNode::EPivotSet::eSourcePivot);
-  const fbxsdk::FbxMatrix vertexTransform =
-      fbxsdk::FbxAMatrix{meshTranslation, meshRotation, meshScaling};
+  const fbxsdk::FbxMatrix vertexTransform = fbxsdk::FbxAMatrix{
+      _applyUnitScaleFactorV3(meshTranslation), meshRotation, meshScaling};
   const fbxsdk::FbxMatrix normalTransform =
       fbxsdk::FbxAMatrix{fbxsdk::FbxVector4(), meshRotation, meshScaling};
   auto normalTransformIT = normalTransform.Inverse().Transpose();
@@ -189,7 +189,7 @@ fx::gltf::Primitive SceneConverter::_convertMeshAsPrimitive(
 
     // Position
     {
-      auto position = controlPoints[iControlPoint];
+      auto position = _applyUnitScaleFactorV3(controlPoints[iControlPoint]);
       if (vertex_transform_) {
         position = vertex_transform_->MultNormalize(position);
       }
@@ -252,7 +252,8 @@ fx::gltf::Primitive SceneConverter::_convertMeshAsPrimitive(
     // Shapes
     for (auto &[controlPoints, normalElement] : vertexLayout.shapes) {
       {
-        auto shapePosition = controlPoints.element[iControlPoint];
+        auto shapePosition =
+            _applyUnitScaleFactorV3(controlPoints.element[iControlPoint]);
         if (vertex_transform_) {
           shapePosition = vertex_transform_->MultNormalize(shapePosition);
         }

--- a/Core/Source/bee/Convert/SceneConverter.h
+++ b/Core/Source/bee/Convert/SceneConverter.h
@@ -225,6 +225,15 @@ private:
   std::unordered_map<fbxsdk::FbxUInt64, std::optional<GLTFBuilder::XXIndex>>
       _textureMap;
   std::unordered_map<const fbxsdk::FbxNode *, FbxNodeDumpMeta> _nodeDumpMetaMap;
+  std::optional<fbxsdk::FbxDouble> _unitScaleFactor = 1.0;
+
+  inline fbxsdk::FbxVector4
+  _applyUnitScaleFactorV3(const fbxsdk::FbxVector4 &v_) const {
+    return _unitScaleFactor ? fbxsdk::FbxVector4{v_[0] * (*_unitScaleFactor),
+                                                 v_[1] * (*_unitScaleFactor),
+                                                 v_[2] * (*_unitScaleFactor)}
+                            : v_;
+  }
 
   /// <summary>
   /// Prefer std::u8string_view overloading.

--- a/Core/Source/bee/Converter.h
+++ b/Core/Source/bee/Converter.h
@@ -48,6 +48,12 @@ public:
 };
 
 struct ConvertOptions {
+  enum class UnitConversion {
+    disabled,
+    hierarchyLevel,
+    geometryLevel,
+  };
+
   std::u8string out;
 
   GLTFWriter *writer = nullptr;
@@ -55,6 +61,8 @@ struct ConvertOptions {
   std::optional<std::u8string_view> fbmDir;
 
   bool useDataUriForBuffers = true;
+
+  UnitConversion unitConversion = UnitConversion::geometryLevel;
 
   bool noFlipV = false;
 


### PR DESCRIPTION
- Add option `--unit-conversion`, possible values are `geometry-level`, `hierarchy-level` and `disabled`.

### Remarks

We use FBX SDK's `FBXSystemUnit::convertScene()` to convert FBX files' system units into the one glTF required(current, meter). FBX SDK will simply scale the scene root nodes will the scale factor. This works fine when do rendering, but causes problems especially when user want to bind one FBX model onto the bone in another FBX model, even if the two FBX files have same system unit. For example, FBX `A` and FBX `B` essentially use centimeters, let's imagine them with actor and weapon. Any meshes bound to the actor's bone expected to in centimeters. When binding root of weapon onto bones of actor, the weapon's root node has already been in meters which results the weapon can never been correctly scaled.

To overcome this, we can only perform the unit conversion in "geometry level", that's why this option comes. If `--unit-conversion` is set to `geometry-level`, the following "positions" are scaled to match glTF's requirement:
- Vertex positions(in FBX domain, control points);
- Morph positions(in FBX domain, shape positions);
- Node local translations and node geometry translations(FBX specific);
- Node local translation animations;
In additions, the scale factor would also applied to inverse bind matrices.

See related discussion in `FBX2glTF`: https://github.com/facebookincubator/FBX2glTF/issues/29 and its process: https://github.com/facebookincubator/FBX2glTF/pull/63

However personally I do not have confidence with this process - have we been caught all scale cases? So I made this option default and allow the original behaviour.

Note, this is a breaking change in fact.