### PR TITLE
Fix non-ASCII encoding in texture path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out/
 
 
 vcpkg_installed/
+
+.vscode/settings.json

--- a/Core/Source/bee/Convert/SceneConverter.Texture.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Texture.cpp
@@ -111,9 +111,9 @@ std::optional<GLTFBuilder::XXIndex> SceneConverter::_convertTextureSource(
   }
 
   glTFImage.extensionsAndExtras["extras"]["FBX-glTF-conv"]["fileName"] =
-      imageFileName;
+      forceTreatAsPlain(imageFileName);
   glTFImage.extensionsAndExtras["extras"]["FBX-glTF-conv"]["relativeFileName"] =
-      imageFileNameRelative;
+      forceTreatAsPlain(imageFileNameRelative);
 
   auto glTFImageIndex =
       _glTFBuilder.add(&fx::gltf::Document::images, std::move(glTFImage));

--- a/Core/Source/bee/Convert/SceneConverter.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.cpp
@@ -159,8 +159,8 @@ std::string SceneConverter::_convertName(const char *fbx_name_) {
   return fbx_name_;
 }
 
-std::string SceneConverter::_convertFileName(const char *fbx_file_name_) {
-  return fbx_file_name_;
+std::u8string SceneConverter::_convertFileName(const char *fbx_file_name_) {
+  return std::u8string{reinterpret_cast<const char8_t *>(fbx_file_name_)};
 }
 
 GLTFBuilder::XXIndex

--- a/Core/Source/bee/Convert/SceneConverter.h
+++ b/Core/Source/bee/Convert/SceneConverter.h
@@ -262,7 +262,7 @@ private:
 
   std::string _convertName(const char *fbx_name_);
 
-  std::string _convertFileName(const char *fbx_file_name_);
+  std::u8string _convertFileName(const char *fbx_file_name_);
 
   GLTFBuilder::XXIndex _convertScene(fbxsdk::FbxScene &fbx_scene_);
 


### PR DESCRIPTION
`"레드캐릭터본네임수정\\촉\\제갈량(완)\\스킨"` is such a path causes problem