### PR TITLE
Release 1.0.0-alpha.18; Export unknown material(tested for 3ds Max physical materials)

### DIFF
--- a/Core/Source/bee/Convert/SceneConverter.Animation.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Animation.cpp
@@ -111,6 +111,9 @@ void SceneConverter::_convertAnimation(fbxsdk::FbxScene &fbx_scene_) {
     fx::gltf::Animation glTFAnimation;
     const auto animName = _convertName(animStack->GetName());
     glTFAnimation.name = animName;
+
+    _log(Logger::Level::verbose, fmt::format("Take {}: {}s", animName, timeSpan.GetDuration().GetSecondDouble()));
+
     fbx_scene_.SetCurrentAnimationStack(animStack);
     for (std::remove_const_t<decltype(nAnimLayers)> iAnimLayer = 0;
          iAnimLayer < nAnimLayers; ++iAnimLayer) {

--- a/Core/Source/bee/Convert/SceneConverter.Mesh.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Mesh.cpp
@@ -436,8 +436,7 @@ SceneConverter::_createPrimitive(std::list<VertexBulk> &bulks_,
       glTFBufferView.name =
           fmt::format("{}/Target-{}", primitive_name_, *bulk.morphTargetHint);
     } else {
-      glTFBufferView.name =
-          fmt::format("{}", primitive_name_, *bulk.morphTargetHint);
+      glTFBufferView.name = fmt::format("{}", primitive_name_);
     }
     if (bulk.vertexBuffer) {
       glTFBufferView.target = fx::gltf::BufferView::TargetType::ArrayBuffer;

--- a/Core/Source/bee/Convert/SceneConverter.Texture.cpp
+++ b/Core/Source/bee/Convert/SceneConverter.Texture.cpp
@@ -9,22 +9,27 @@ std::optional<GLTFBuilder::XXIndex>
 SceneConverter::_convertTextureProperty(fbxsdk::FbxProperty &fbx_property_) {
   const auto fbxFileTexture =
       fbx_property_.GetSrcObject<fbxsdk::FbxFileTexture>();
-  if (!fbxFileTexture) {
+  if (fbxFileTexture) {
+    return _convertFileTextureShared(*fbxFileTexture);
+  } else {
     const auto fbxTexture = fbx_property_.GetSrcObject<fbxsdk::FbxTexture>();
     if (fbxTexture) {
       _log(Logger::Level::verbose,
            u8"The property is texture but is not file texture. It's ignored.");
     }
     return {};
+  }
+}
+
+std::optional<GLTFBuilder::XXIndex> SceneConverter::_convertFileTextureShared(
+    fbxsdk::FbxFileTexture &fbx_file_texture_) {
+  auto fbxTextureId = fbx_file_texture_.GetUniqueID();
+  if (auto r = _textureMap.find(fbxTextureId); r != _textureMap.end()) {
+    return r->second;
   } else {
-    auto fbxTextureId = fbxFileTexture->GetUniqueID();
-    if (auto r = _textureMap.find(fbxTextureId); r != _textureMap.end()) {
-      return r->second;
-    } else {
-      auto glTFTextureIndex = _convertFileTexture(*fbxFileTexture);
-      _textureMap.emplace(fbxTextureId, glTFTextureIndex);
-      return glTFTextureIndex;
-    }
+    auto glTFTextureIndex = _convertFileTexture(fbx_file_texture_);
+    _textureMap.emplace(fbxTextureId, glTFTextureIndex);
+    return glTFTextureIndex;
   }
 }
 

--- a/Core/Source/bee/Convert/SceneConverter.h
+++ b/Core/Source/bee/Convert/SceneConverter.h
@@ -348,7 +348,18 @@ private:
                           const MaterialUsage &material_usage_);
 
   std::optional<GLTFBuilder::XXIndex>
+  _convertUnknownMaterial(fbxsdk::FbxSurfaceMaterial &fbx_material_,
+                          const MaterialUsage &material_usage_);
+
+  std::optional<GLTFBuilder::XXIndex>
+  _convertStanardMaterialProperties(fbxsdk::FbxSurfaceMaterial &fbx_material_,
+                                    const MaterialUsage &material_usage_);
+
+  std::optional<GLTFBuilder::XXIndex>
   _convertTextureProperty(fbxsdk::FbxProperty &fbx_property_);
+
+  std::optional<GLTFBuilder::XXIndex>
+  _convertFileTextureShared(fbxsdk::FbxFileTexture &fbx_file_texture_);
 
   std::optional<GLTFBuilder::XXIndex>
   _convertFileTexture(const fbxsdk::FbxFileTexture &fbx_texture_);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,17 +1,18 @@
 {
-    "name": "fbx-gltf-conv",
-    "version-string": "1.0.0-alpha.0",
-    "maintainers": ["Leslie Leigh <leslieleigh@outlook.com>"],
-    "description": "A FBX to glTF file format converter.",
-    "license": "MIT",
-    "supports": "windows & osx",
-    "dependencies": [
-        "libxml2",
-        "zlib",
-        "nlohmann-json",
-        "fmt",
-        "cppcodec",
-        "range-v3",
-        "clipp"
-    ]
+  "name": "fbx-gltf-conv",
+  "version-string": "1.0.0-alpha.0",
+  "maintainers": [ "Leslie Leigh <leslieleigh@outlook.com>" ],
+  "description": "A FBX to glTF file format converter.",
+  "license": "MIT",
+  "supports": "windows & osx",
+  "dependencies": [
+    "libxml2",
+    "zlib",
+    "nlohmann-json",
+    "fmt",
+    "cppcodec",
+    "range-v3",
+    "clipp",
+    "glm"
+  ]
 }


### PR DESCRIPTION
- Non-lambert materials now have its original data exported as glTF extra: `['extras']['FBX-glTF-conv']['originalMaterial']`